### PR TITLE
Support workspaceFolder variable with --workspace-folder option

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/garaemon/jtask/internal/config"
 	"github.com/garaemon/jtask/internal/discovery"
@@ -10,6 +11,7 @@ import (
 )
 
 var dryRun bool
+var workspaceFolder string
 
 var runCommand = &cobra.Command{
 	Use:   "run <task-name>",
@@ -21,6 +23,29 @@ var runCommand = &cobra.Command{
 
 func executeRunCommand(cmd *cobra.Command, args []string) error {
 	taskName := args[0]
+
+	// Determine workspace folder
+	var workspaceDir string
+	if workspaceFolder != "" {
+		workspaceDir = workspaceFolder
+	} else {
+		// Default to git root
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+		gitRoot, err := discovery.FindGitRoot(currentDir)
+		if err != nil {
+			// Fall back to current directory if git root not found
+			workspaceDir = currentDir
+		} else {
+			workspaceDir = gitRoot
+		}
+	}
+
+	if verbose {
+		fmt.Printf("Workspace folder: %s\n", workspaceDir)
+	}
 
 	tasksFilePath, err := discovery.FindTasksFile(configPath)
 	if err != nil {
@@ -62,10 +87,11 @@ func executeRunCommand(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Executing task: %s\n", targetTask.Label)
 	}
 
-	return executor.RunTask(targetTask)
+	return executor.RunTask(targetTask, workspaceDir)
 }
 
 func init() {
 	runCommand.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be executed without running")
+	runCommand.Flags().StringVar(&workspaceFolder, "workspace-folder", "", "workspace folder path (defaults to git root)")
 	rootCmd.AddCommand(runCommand)
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -77,5 +79,458 @@ func TestExecuteRunCommand_TasksFileNotFound(t *testing.T) {
 	
 	if err == nil {
 		t.Error("expected error for non-existent tasks file")
+	}
+}
+
+func TestExecuteRunCommand_WithWorkspaceFolder(t *testing.T) {
+	configPath = "../testdata/workspace_tasks.json"
+	workspaceFolder = "/test/workspace"
+	defer func() { workspaceFolder = "" }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"workspace-build"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	if !strings.Contains(output, "echo building in /test/workspace") {
+		t.Errorf("expected workspace folder substitution in output, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_WorkspaceFolderWithArgs(t *testing.T) {
+	configPath = "../testdata/workspace_tasks.json"
+	workspaceFolder = "/test/workspace"
+	defer func() { workspaceFolder = "" }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"workspace-args"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	if !strings.Contains(output, "Args: [-la /test/workspace]") {
+		t.Errorf("expected workspace folder substitution in args, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_VerboseOutput(t *testing.T) {
+	configPath = "../testdata/simple_tasks.json"
+	verbose = true
+	defer func() { verbose = false }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"build"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	if !strings.Contains(output, "Workspace folder:") {
+		t.Errorf("expected workspace folder info in verbose output, got %s", output)
+	}
+	if !strings.Contains(output, "Using tasks file:") {
+		t.Errorf("expected tasks file info in verbose output, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_QuietMode(t *testing.T) {
+	configPath = "../testdata/simple_tasks.json"
+	quiet = true
+	defer func() { quiet = false }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"build"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	if strings.Contains(output, "Executing task:") {
+		t.Errorf("expected no execution message in quiet mode, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_GitRootFallback(t *testing.T) {
+	// Create a temporary directory structure with git
+	tempDir, err := os.MkdirTemp("", "git-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	
+	// Create .git directory
+	gitDir := filepath.Join(tempDir, ".git")
+	if err := os.Mkdir(gitDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	
+	// Create testdata and tasks file in temp dir
+	testdataDir := filepath.Join(tempDir, "testdata")
+	if err := os.Mkdir(testdataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	
+	tasksFile := filepath.Join(testdataDir, "simple_tasks.json")
+	if err := os.WriteFile(tasksFile, []byte(`{
+		"version": "2.0.0",
+		"tasks": [
+			{
+				"label": "test-task",
+				"type": "shell",
+				"command": "echo test"
+			}
+		]
+	}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	
+	// Change to temp directory
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	_ = os.Chdir(tempDir)
+	
+	configPath = "testdata/simple_tasks.json"
+	workspaceFolder = ""
+	verbose = true
+	defer func() { verbose = false }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"test-task"}
+	
+	err = executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	// tempDir might have symbolic links resolved, so check if the output contains the directory name
+	if !strings.Contains(output, "Workspace folder:") || !strings.Contains(output, "git-test") {
+		t.Errorf("expected git root as workspace folder, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_NoGitFallbackToCwd(t *testing.T) {
+	// Create a temporary directory without git
+	tempDir, err := os.MkdirTemp("", "no-git-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	
+	// Create testdata and tasks file in temp dir
+	testdataDir := filepath.Join(tempDir, "testdata")
+	if err := os.Mkdir(testdataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	
+	tasksFile := filepath.Join(testdataDir, "simple_tasks.json")
+	if err := os.WriteFile(tasksFile, []byte(`{
+		"version": "2.0.0",
+		"tasks": [
+			{
+				"label": "test-task",
+				"type": "shell",
+				"command": "echo test"
+			}
+		]
+	}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	
+	// Change to temp directory
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	_ = os.Chdir(tempDir)
+	
+	configPath = "testdata/simple_tasks.json"
+	workspaceFolder = ""
+	verbose = true
+	defer func() { verbose = false }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"test-task"}
+	
+	err = executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	// tempDir might have symbolic links resolved, so check if the output contains the directory name
+	if !strings.Contains(output, "Workspace folder:") || !strings.Contains(output, "no-git-test") {
+		t.Errorf("expected current directory as workspace folder fallback, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_ComplexTaskWithOptions(t *testing.T) {
+	configPath = "../testdata/complex_tasks.json"
+	workspaceFolder = "/test/workspace"
+	defer func() { workspaceFolder = "" }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"compile"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	if !strings.Contains(output, "Would execute task: compile") {
+		t.Errorf("expected task execution info, got %s", output)
+	}
+	if !strings.Contains(output, "Type: process") {
+		t.Errorf("expected task type info, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_WorkspaceFolderAbsolutePath(t *testing.T) {
+	configPath = "../testdata/workspace_tasks.json"
+	workspaceFolder = "/absolute/path/to/workspace"
+	defer func() { workspaceFolder = "" }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"workspace-cwd"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	// Note: The cwd option is not shown in dry-run output, but the workspace substitution should occur
+	if !strings.Contains(output, "Would execute task: workspace-cwd") {
+		t.Errorf("expected task execution with workspace folder, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_GetCurrentDirError(t *testing.T) {
+	// This test is difficult to create a real scenario for os.Getwd() error
+	// but we can test the error handling path by checking the error message structure
+	configPath = "../testdata/simple_tasks.json"
+	workspaceFolder = ""
+	
+	// We'll verify the function structure handles errors properly
+	cmd := &cobra.Command{}
+	args := []string{"build"}
+	
+	// In normal circumstances, this should not error
+	err := executeRunCommand(cmd, args)
+	if err != nil {
+		// If there's an error, it should be meaningful
+		if !strings.Contains(err.Error(), "failed to") {
+			t.Errorf("expected meaningful error message, got %s", err.Error())
+		}
+	}
+}
+
+func TestExecuteRunCommand_EmptyWorkspaceFolder(t *testing.T) {
+	configPath = "../testdata/workspace_tasks.json"
+	workspaceFolder = ""
+	dryRun = true
+	defer func() { dryRun = false }()
+	verbose = true
+	defer func() { verbose = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"workspace-build"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	// Should show workspace folder determination
+	if !strings.Contains(output, "Workspace folder:") {
+		t.Errorf("expected workspace folder info in verbose output, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_RelativeWorkspaceFolder(t *testing.T) {
+	configPath = "../testdata/workspace_tasks.json"
+	workspaceFolder = "./relative/path"
+	defer func() { workspaceFolder = "" }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"workspace-build"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	if !strings.Contains(output, "echo building in ./relative/path") {
+		t.Errorf("expected relative workspace folder substitution, got %s", output)
+	}
+}
+
+func TestExecuteRunCommand_TaskWithoutWorkspaceVar(t *testing.T) {
+	configPath = "../testdata/simple_tasks.json"
+	workspaceFolder = "/test/workspace"
+	defer func() { workspaceFolder = "" }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"test"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	// Should work fine even if task doesn't use workspace folder variables
+}
+
+func TestExecuteRunCommand_MultipleWorkspaceVars(t *testing.T) {
+	// Create a test file with multiple workspace folder references
+	configPath = "../testdata/workspace_tasks.json"
+	workspaceFolder = "/test/workspace"
+	defer func() { workspaceFolder = "" }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"workspace-env"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	if !strings.Contains(output, "Would execute task: workspace-env") {
+		t.Errorf("expected task execution with multiple workspace variables, got %s", output)
 	}
 }

--- a/internal/discovery/git.go
+++ b/internal/discovery/git.go
@@ -1,0 +1,25 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// FindGitRoot recursively searches for git root directory starting from the given path
+func FindGitRoot(startPath string) (string, error) {
+	currentPath := startPath
+	
+	for {
+		gitPath := filepath.Join(currentPath, ".git")
+		if info, err := os.Stat(gitPath); err == nil && info.IsDir() {
+			return currentPath, nil
+		}
+		
+		parentPath := filepath.Dir(currentPath)
+		if parentPath == currentPath {
+			// Reached root directory without finding .git
+			return "", os.ErrNotExist
+		}
+		currentPath = parentPath
+	}
+}

--- a/internal/discovery/git_test.go
+++ b/internal/discovery/git_test.go
@@ -1,0 +1,62 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindGitRoot(t *testing.T) {
+	// Create a temporary directory structure
+	tempDir, err := os.MkdirTemp("", "git-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Create .git directory
+	gitDir := filepath.Join(tempDir, ".git")
+	if err := os.Mkdir(gitDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create subdirectory
+	subDir := filepath.Join(tempDir, "subdir")
+	if err := os.Mkdir(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test finding git root from subdirectory
+	gitRoot, err := FindGitRoot(subDir)
+	if err != nil {
+		t.Fatalf("Expected to find git root, got error: %v", err)
+	}
+
+	if gitRoot != tempDir {
+		t.Errorf("Expected git root to be %s, got %s", tempDir, gitRoot)
+	}
+
+	// Test finding git root from git directory itself
+	gitRoot, err = FindGitRoot(tempDir)
+	if err != nil {
+		t.Fatalf("Expected to find git root, got error: %v", err)
+	}
+
+	if gitRoot != tempDir {
+		t.Errorf("Expected git root to be %s, got %s", tempDir, gitRoot)
+	}
+}
+
+func TestFindGitRootNotFound(t *testing.T) {
+	// Create a temporary directory without .git
+	tempDir, err := os.MkdirTemp("", "no-git-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	_, err = FindGitRoot(tempDir)
+	if err != os.ErrNotExist {
+		t.Errorf("Expected os.ErrNotExist, got %v", err)
+	}
+}

--- a/testdata/workspace_tasks.json
+++ b/testdata/workspace_tasks.json
@@ -1,0 +1,36 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "workspace-build",
+      "type": "shell",
+      "command": "echo building in ${workspaceFolder}",
+      "group": "build"
+    },
+    {
+      "label": "workspace-cwd",
+      "type": "process",
+      "command": "pwd",
+      "options": {
+        "cwd": "${workspaceFolder}/subdir"
+      }
+    },
+    {
+      "label": "workspace-env",
+      "type": "shell",
+      "command": "echo $PROJECT_ROOT",
+      "options": {
+        "env": {
+          "PROJECT_ROOT": "${workspaceFolder}",
+          "BUILD_DIR": "${workspaceFolder}/build"
+        }
+      }
+    },
+    {
+      "label": "workspace-args",
+      "type": "shell",
+      "command": "ls",
+      "args": ["-la", "${workspaceFolder}"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `--workspace-folder` option to `run` command that defaults to git root directory
- Implement `${workspaceFolder}` variable substitution in task commands, arguments, working directory, and environment variables
- Add git root detection with recursive directory traversal up to filesystem root

## Test plan
- [x] All existing tests pass
- [x] New tests for git root detection functionality
- [x] New tests for workspaceFolder variable substitution
- [x] Linter passes without issues
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)