### PR TITLE
Add JSONC support for tasks.json parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/tidwall/jsonc v0.3.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
+github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/tidwall/jsonc"
 )
 
 func parseTasksFile(filePath string) (*TasksFile, error) {
@@ -12,8 +14,11 @@ func parseTasksFile(filePath string) (*TasksFile, error) {
 		return nil, fmt.Errorf("failed to read tasks file: %w", err)
 	}
 
+	// Parse JSONC (JSON with comments and trailing commas)
+	jsonData := jsonc.ToJSON(data)
+	
 	var tasksFile TasksFile
-	if err := json.Unmarshal(data, &tasksFile); err != nil {
+	if err := json.Unmarshal(jsonData, &tasksFile); err != nil {
 		return nil, fmt.Errorf("failed to parse tasks file: %w", err)
 	}
 

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -108,6 +108,50 @@ func TestLoadTasks_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoadTasks_JSONC(t *testing.T) {
+	testFile := filepath.Join("..", "..", "testdata", "jsonc_tasks.json")
+	
+	tasks, err := LoadTasks(testFile)
+	if err != nil {
+		t.Fatalf("LoadTasks failed for JSONC file: %v", err)
+	}
+	
+	if len(tasks) != 2 {
+		t.Fatalf("Expected 2 tasks, got %d", len(tasks))
+	}
+	
+	buildTask := tasks[0]
+	if buildTask.Label != "build" {
+		t.Errorf("Expected label 'build', got '%s'", buildTask.Label)
+	}
+	if buildTask.Type != "shell" {
+		t.Errorf("Expected type 'shell', got '%s'", buildTask.Type)
+	}
+	if buildTask.Command != "go build" {
+		t.Errorf("Expected command 'go build', got '%s'", buildTask.Command)
+	}
+	if buildTask.GetGroupKind() != "build" {
+		t.Errorf("Expected group 'build', got '%s'", buildTask.GetGroupKind())
+	}
+	
+	testTask := tasks[1]
+	if testTask.Label != "test" {
+		t.Errorf("Expected label 'test', got '%s'", testTask.Label)
+	}
+	if len(testTask.Args) != 2 {
+		t.Errorf("Expected 2 args, got %d", len(testTask.Args))
+	}
+	if testTask.Args[0] != "-v" || testTask.Args[1] != "./..." {
+		t.Errorf("Expected args ['-v', './...'], got %v", testTask.Args)
+	}
+	if testTask.GetGroupKind() != "test" {
+		t.Errorf("Expected group 'test', got '%s'", testTask.GetGroupKind())
+	}
+	if !testTask.IsDefaultInGroup() {
+		t.Error("Expected test task to be default in group")
+	}
+}
+
 func TestTask_GetGroupKind(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/testdata/jsonc_tasks.json
+++ b/testdata/jsonc_tasks.json
@@ -1,0 +1,22 @@
+{
+    // Example tasks.json with JSONC format (comments and trailing commas)
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "go build", // This is a comment
+            "group": "build",
+        },
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "go test",
+            "args": ["-v", "./..."], // Another comment
+            "group": {
+                "kind": "test",
+                "isDefault": true, // Trailing comma
+            },
+        }, // Trailing comma after last task
+    ]
+}


### PR DESCRIPTION
## Summary
- Add support for parsing JSONC (JSON with comments and trailing commas) in tasks.json files
- Uses `github.com/tidwall/jsonc` library to handle VS Code's tasks.json format
- Maintains backward compatibility with standard JSON

## Test plan
- [x] Added comprehensive test coverage for JSONC parsing
- [x] Verified existing tests still pass
- [x] Created test data with comments and trailing commas
- [x] All tests pass and linter checks succeed

🤖 Generated with [Claude Code](https://claude.ai/code)