### PR TITLE
Add support for ${file} variable with --file option

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -534,3 +534,33 @@ func TestExecuteRunCommand_MultipleWorkspaceVars(t *testing.T) {
 		t.Errorf("expected task execution with multiple workspace variables, got %s", output)
 	}
 }
+
+func TestExecuteRunCommand_WithFile(t *testing.T) {
+	configPath = "../testdata/file_tasks.json"
+	file = "src/main.go"
+	defer func() { file = "" }()
+	dryRun = true
+	defer func() { dryRun = false }()
+	
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+	
+	cmd := &cobra.Command{}
+	args := []string{"format-file"}
+	
+	err := executeRunCommand(cmd, args)
+	
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	
+	output := string(out)
+	if !strings.Contains(output, "Command: fmt src/main.go") {
+		t.Errorf("expected file variable substitution in output, got %s", output)
+	}
+}

--- a/testdata/file_tasks.json
+++ b/testdata/file_tasks.json
@@ -1,0 +1,22 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "format-file",
+			"type": "shell",
+			"command": "fmt ${file}"
+		},
+		{
+			"label": "lint-file",
+			"type": "process",
+			"command": "golint",
+			"args": ["${file}"]
+		},
+		{
+			"label": "check-file",
+			"type": "shell",
+			"command": "cat ${workspaceFolder}/${file}",
+			"args": ["${file}"]
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Add `--file` flag to run command enabling file path substitution for `${file}` variables
- Implement comprehensive variable replacement in task commands, arguments, and options 
- Extend existing variable substitution system to handle both `${workspaceFolder}` and `${file}` variables

## Test plan
- [x] All existing tests continue to pass
- [x] New tests added for file variable functionality
- [x] Manual testing confirms proper variable substitution
- [x] Linting passes with no issues
- [x] Help text updated to document new flag

🤖 Generated with [Claude Code](https://claude.ai/code)