### PR TITLE
Add VS Code file-related variable support

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -166,6 +166,12 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 		}
 	}
 	
+	// Get relative file directory path for ${relativeFileDirname} variable
+	relativeFileDirname := ""
+	if relativeFile != "" {
+		relativeFileDirname = filepath.Dir(relativeFile)
+	}
+	
 	// Create a copy of the task to avoid modifying the original
 	substituted := *task
 	
@@ -179,6 +185,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileExtname}", fileExtname)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileWorkspaceFolder}", fileWorkspaceFolder)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${relativeFile}", relativeFile)
+	substituted.Command = strings.ReplaceAll(substituted.Command, "${relativeFileDirname}", relativeFileDirname)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${cwd}", cwd)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${pathSeparator}", pathSeparator)
 	substituted.Command = substituteEnvVariables(substituted.Command)
@@ -196,6 +203,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileExtname}", fileExtname)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileWorkspaceFolder}", fileWorkspaceFolder)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${relativeFile}", relativeFile)
+			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${relativeFileDirname}", relativeFileDirname)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${cwd}", cwd)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${pathSeparator}", pathSeparator)
 			substituted.Args[i] = substituteEnvVariables(substituted.Args[i])
@@ -217,6 +225,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileExtname}", fileExtname)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileWorkspaceFolder}", fileWorkspaceFolder)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${relativeFile}", relativeFile)
+			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${relativeFileDirname}", relativeFileDirname)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${cwd}", cwd)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${pathSeparator}", pathSeparator)
 			substituted.Options.Cwd = substituteEnvVariables(substituted.Options.Cwd)
@@ -234,6 +243,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileExtname}", fileExtname)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileWorkspaceFolder}", fileWorkspaceFolder)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${relativeFile}", relativeFile)
+				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${relativeFileDirname}", relativeFileDirname)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${cwd}", cwd)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${pathSeparator}", pathSeparator)
 				substituted.Options.Env[key] = substituteEnvVariables(substituted.Options.Env[key])

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -135,6 +135,22 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 		fileExtname = filepath.Ext(file)
 	}
 	
+	// Get workspace folder of the current file for ${fileWorkspaceFolder} variable
+	fileWorkspaceFolder := ""
+	if file != "" {
+		// If file is absolute path, check if it's within workspace
+		if filepath.IsAbs(file) {
+			// Check if file is within the workspace directory
+			rel, err := filepath.Rel(workspaceDir, file)
+			if err == nil && !strings.HasPrefix(rel, "..") {
+				fileWorkspaceFolder = workspaceDir
+			}
+		} else {
+			// If file is relative, assume it's relative to workspace
+			fileWorkspaceFolder = workspaceDir
+		}
+	}
+	
 	// Create a copy of the task to avoid modifying the original
 	substituted := *task
 	
@@ -146,6 +162,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileBasenameNoExtension}", fileBasenameNoExtension)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileDirname}", fileDirname)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileExtname}", fileExtname)
+	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileWorkspaceFolder}", fileWorkspaceFolder)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${cwd}", cwd)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${pathSeparator}", pathSeparator)
 	substituted.Command = substituteEnvVariables(substituted.Command)
@@ -161,6 +178,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileBasenameNoExtension}", fileBasenameNoExtension)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileDirname}", fileDirname)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileExtname}", fileExtname)
+			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileWorkspaceFolder}", fileWorkspaceFolder)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${cwd}", cwd)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${pathSeparator}", pathSeparator)
 			substituted.Args[i] = substituteEnvVariables(substituted.Args[i])
@@ -180,6 +198,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileBasenameNoExtension}", fileBasenameNoExtension)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileDirname}", fileDirname)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileExtname}", fileExtname)
+			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileWorkspaceFolder}", fileWorkspaceFolder)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${cwd}", cwd)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${pathSeparator}", pathSeparator)
 			substituted.Options.Cwd = substituteEnvVariables(substituted.Options.Cwd)
@@ -195,6 +214,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileBasenameNoExtension}", fileBasenameNoExtension)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileDirname}", fileDirname)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileExtname}", fileExtname)
+				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileWorkspaceFolder}", fileWorkspaceFolder)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${cwd}", cwd)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${pathSeparator}", pathSeparator)
 				substituted.Options.Env[key] = substituteEnvVariables(substituted.Options.Env[key])

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -151,6 +151,21 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 		}
 	}
 	
+	// Get relative file path for ${relativeFile} variable
+	relativeFile := ""
+	if file != "" {
+		if filepath.IsAbs(file) {
+			// If file is absolute, get relative path from workspace
+			rel, err := filepath.Rel(workspaceDir, file)
+			if err == nil && !strings.HasPrefix(rel, "..") {
+				relativeFile = rel
+			}
+		} else {
+			// If file is already relative, use as is
+			relativeFile = file
+		}
+	}
+	
 	// Create a copy of the task to avoid modifying the original
 	substituted := *task
 	
@@ -163,6 +178,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileDirname}", fileDirname)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileExtname}", fileExtname)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${fileWorkspaceFolder}", fileWorkspaceFolder)
+	substituted.Command = strings.ReplaceAll(substituted.Command, "${relativeFile}", relativeFile)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${cwd}", cwd)
 	substituted.Command = strings.ReplaceAll(substituted.Command, "${pathSeparator}", pathSeparator)
 	substituted.Command = substituteEnvVariables(substituted.Command)
@@ -179,6 +195,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileDirname}", fileDirname)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileExtname}", fileExtname)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${fileWorkspaceFolder}", fileWorkspaceFolder)
+			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${relativeFile}", relativeFile)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${cwd}", cwd)
 			substituted.Args[i] = strings.ReplaceAll(substituted.Args[i], "${pathSeparator}", pathSeparator)
 			substituted.Args[i] = substituteEnvVariables(substituted.Args[i])
@@ -199,6 +216,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileDirname}", fileDirname)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileExtname}", fileExtname)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${fileWorkspaceFolder}", fileWorkspaceFolder)
+			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${relativeFile}", relativeFile)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${cwd}", cwd)
 			substituted.Options.Cwd = strings.ReplaceAll(substituted.Options.Cwd, "${pathSeparator}", pathSeparator)
 			substituted.Options.Cwd = substituteEnvVariables(substituted.Options.Cwd)
@@ -215,6 +233,7 @@ func substituteVariables(task *config.Task, workspaceDir string, file string) *c
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileDirname}", fileDirname)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileExtname}", fileExtname)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${fileWorkspaceFolder}", fileWorkspaceFolder)
+				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${relativeFile}", relativeFile)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${cwd}", cwd)
 				substituted.Options.Env[key] = strings.ReplaceAll(substituted.Options.Env[key], "${pathSeparator}", pathSeparator)
 				substituted.Options.Env[key] = substituteEnvVariables(substituted.Options.Env[key])

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -1050,3 +1050,83 @@ func TestSubstituteVariables_FileExtnameEdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestSubstituteVariables_WithFileWorkspaceFolder(t *testing.T) {
+	workspaceDir := "/home/user/project"
+	
+	tests := []struct {
+		file     string
+		expected string
+		name     string
+	}{
+		{
+			file:     "src/main.go",
+			expected: workspaceDir,
+			name:     "relative file within workspace",
+		},
+		{
+			file:     "/home/user/project/src/components/Button.tsx",
+			expected: workspaceDir,
+			name:     "absolute file within workspace",
+		},
+		{
+			file:     "/home/user/other-project/main.go",
+			expected: "",
+			name:     "absolute file outside workspace",
+		},
+		{
+			file:     "",
+			expected: "",
+			name:     "empty file path",
+		},
+	}
+	
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			task := &config.Task{
+				Type:    "shell",
+				Command: "echo ${fileWorkspaceFolder}",
+				Args:    []string{"--workspace", "${fileWorkspaceFolder}", "test"},
+				Options: &config.TaskOptions{
+					Cwd: "${fileWorkspaceFolder}/build",
+					Env: map[string]string{
+						"FILE_WORKSPACE": "${fileWorkspaceFolder}",
+						"BUILD_PATH":     "${fileWorkspaceFolder}/dist",
+					},
+				},
+			}
+			
+			substituted := substituteVariables(task, workspaceDir, test.file)
+			
+			expectedCommand := "echo " + test.expected
+			if substituted.Command != expectedCommand {
+				t.Errorf("expected command to be '%s', got '%s'", expectedCommand, substituted.Command)
+			}
+			
+			expectedArgs := []string{"--workspace", test.expected, "test"}
+			if len(substituted.Args) != len(expectedArgs) {
+				t.Errorf("expected %d args, got %d", len(expectedArgs), len(substituted.Args))
+			}
+			
+			for i, arg := range expectedArgs {
+				if substituted.Args[i] != arg {
+					t.Errorf("expected arg %d to be %s, got %s", i, arg, substituted.Args[i])
+				}
+			}
+			
+			expectedCwdPath := test.expected + "/build"
+			if substituted.Options.Cwd != expectedCwdPath {
+				t.Errorf("expected cwd to be '%s', got '%s'", expectedCwdPath, substituted.Options.Cwd)
+			}
+			
+			if substituted.Options.Env["FILE_WORKSPACE"] != test.expected {
+				t.Errorf("expected FILE_WORKSPACE to be '%s', got '%s'", test.expected, substituted.Options.Env["FILE_WORKSPACE"])
+			}
+			
+			expectedBuildPath := test.expected + "/dist"
+			if substituted.Options.Env["BUILD_PATH"] != expectedBuildPath {
+				t.Errorf("expected BUILD_PATH to be '%s', got '%s'", expectedBuildPath, substituted.Options.Env["BUILD_PATH"])
+			}
+		})
+	}
+}

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -1210,3 +1210,88 @@ func TestSubstituteVariables_WithRelativeFile(t *testing.T) {
 		})
 	}
 }
+
+func TestSubstituteVariables_WithRelativeFileDirname(t *testing.T) {
+	workspaceDir := "/home/user/project"
+	
+	tests := []struct {
+		file     string
+		expected string
+		name     string
+	}{
+		{
+			file:     "src/components/main.tsx",
+			expected: "src/components",
+			name:     "relative file with nested directories",
+		},
+		{
+			file:     "/home/user/project/src/utils/helper.js",
+			expected: "src/utils",
+			name:     "absolute file within workspace",
+		},
+		{
+			file:     "main.go",
+			expected: ".",
+			name:     "file in workspace root",
+		},
+		{
+			file:     "/home/user/other-project/main.go",
+			expected: "",
+			name:     "absolute file outside workspace",
+		},
+		{
+			file:     "",
+			expected: "",
+			name:     "empty file path",
+		},
+	}
+	
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			task := &config.Task{
+				Type:    "shell",
+				Command: "echo ${relativeFileDirname}",
+				Args:    []string{"--dir", "${relativeFileDirname}", "test"},
+				Options: &config.TaskOptions{
+					Cwd: "${workspaceFolder}/${relativeFileDirname}",
+					Env: map[string]string{
+						"RELATIVE_DIR": "${relativeFileDirname}",
+						"BUILD_DIR":    "${relativeFileDirname}/dist",
+					},
+				},
+			}
+			
+			substituted := substituteVariables(task, workspaceDir, test.file)
+			
+			expectedCommand := "echo " + test.expected
+			if substituted.Command != expectedCommand {
+				t.Errorf("expected command to be '%s', got '%s'", expectedCommand, substituted.Command)
+			}
+			
+			expectedArgs := []string{"--dir", test.expected, "test"}
+			if len(substituted.Args) != len(expectedArgs) {
+				t.Errorf("expected %d args, got %d", len(expectedArgs), len(substituted.Args))
+			}
+			
+			for i, arg := range expectedArgs {
+				if substituted.Args[i] != arg {
+					t.Errorf("expected arg %d to be %s, got %s", i, arg, substituted.Args[i])
+				}
+			}
+			
+			expectedCwdPath := workspaceDir + "/" + test.expected
+			if substituted.Options.Cwd != expectedCwdPath {
+				t.Errorf("expected cwd to be '%s', got '%s'", expectedCwdPath, substituted.Options.Cwd)
+			}
+			
+			if substituted.Options.Env["RELATIVE_DIR"] != test.expected {
+				t.Errorf("expected RELATIVE_DIR to be '%s', got '%s'", test.expected, substituted.Options.Env["RELATIVE_DIR"])
+			}
+			
+			expectedBuildDir := test.expected + "/dist"
+			if substituted.Options.Env["BUILD_DIR"] != expectedBuildDir {
+				t.Errorf("expected BUILD_DIR to be '%s', got '%s'", expectedBuildDir, substituted.Options.Env["BUILD_DIR"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `${fileWorkspaceFolder}` variable support - returns workspace folder path for current file
- Add `${relativeFile}` variable support - returns file path relative to workspace root  
- Add `${relativeFileDirname}` variable support - returns directory path relative to workspace root

## Test plan
- [x] Comprehensive unit tests for all three variables
- [x] Edge case testing (empty paths, files outside workspace, etc.)
- [x] All existing tests continue to pass
- [x] Integration with command, args, and options substitution

🤖 Generated with [Claude Code](https://claude.ai/code)