### PR TITLE
Implement init command with template support

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"bufio"
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed templates
+var templatesFS embed.FS
+
+var (
+	templateName string
+	forceFlag    bool
+	outputPath   string
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize basic tasks.json file",
+	Long:  `Initialize a basic tasks.json file with template support.`,
+	RunE:  runInitCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().StringVarP(&templateName, "template", "t", "default", "template to use (default, go, node)")
+	initCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "overwrite existing file")
+	initCmd.Flags().StringVarP(&outputPath, "output", "o", "", "output path (default: .vscode/tasks.json)")
+}
+
+func runInitCommand(cmd *cobra.Command, args []string) error {
+	// Determine output path
+	targetPath := outputPath
+	if targetPath == "" {
+		targetPath = ".vscode/tasks.json"
+	}
+
+	// Check if file already exists
+	if !forceFlag {
+		if _, err := os.Stat(targetPath); err == nil {
+			if !confirmOverwrite(targetPath) {
+				fmt.Println("Operation cancelled.")
+				return nil
+			}
+		}
+	}
+
+	// Validate template
+	if !isValidTemplate(templateName) {
+		return fmt.Errorf("invalid template '%s'. Available templates: default, go, node", templateName)
+	}
+
+	// Create directory if it doesn't exist
+	if err := createDirectoryIfNeeded(targetPath); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Load template content
+	templateContent, err := getTemplateContent(templateName)
+	if err != nil {
+		return fmt.Errorf("failed to load template: %w", err)
+	}
+
+	// Write template to file
+	if err := writeTemplateToFile(targetPath, templateContent); err != nil {
+		return fmt.Errorf("failed to write template: %w", err)
+	}
+
+	if !quiet {
+		fmt.Printf("Successfully created %s using '%s' template\n", targetPath, templateName)
+		if verbose {
+			fmt.Printf("Template path: templates/%s.json\n", templateName)
+		}
+	}
+
+	return nil
+}
+
+func isValidTemplate(template string) bool {
+	validTemplates := []string{"default", "go", "node"}
+	for _, valid := range validTemplates {
+		if template == valid {
+			return true
+		}
+	}
+	return false
+}
+
+func confirmOverwrite(path string) bool {
+	if quiet {
+		return false
+	}
+
+	fmt.Printf("File %s already exists. Overwrite? (y/N): ", path)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes"
+}
+
+func createDirectoryIfNeeded(filePath string) error {
+	dir := filepath.Dir(filePath)
+	if dir == "." {
+		return nil
+	}
+
+	return os.MkdirAll(dir, 0755)
+}
+
+func getTemplateContent(templateName string) (string, error) {
+	templatePath := fmt.Sprintf("templates/%s.json", templateName)
+	content, err := templatesFS.ReadFile(templatePath)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func writeTemplateToFile(path string, content string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	return err
+}
+
+func GetAvailableTemplates() []string {
+	return []string{"default", "go", "node"}
+}
+
+func GetTemplateContent(templateName string) (string, error) {
+	return getTemplateContent(templateName)
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,323 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunInitCommand(t *testing.T) {
+	// Save original values
+	origVerbose := verbose
+	origQuiet := quiet
+	origTemplateName := templateName
+	origForceFlag := forceFlag
+	origOutputPath := outputPath
+	defer func() {
+		verbose = origVerbose
+		quiet = origQuiet
+		templateName = origTemplateName
+		forceFlag = origForceFlag
+		outputPath = origOutputPath
+	}()
+
+	// Create temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "jtask-init-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name         string
+		template     string
+		outputPath   string
+		forceFlag    bool
+		setupFunc    func() error
+		expectError  bool
+		checkContent bool
+	}{
+		{
+			name:         "default template",
+			template:     "default",
+			outputPath:   filepath.Join(tempDir, "tasks1.json"),
+			forceFlag:    false,
+			expectError:  false,
+			checkContent: true,
+		},
+		{
+			name:         "go template",
+			template:     "go",
+			outputPath:   filepath.Join(tempDir, "tasks2.json"),
+			forceFlag:    false,
+			expectError:  false,
+			checkContent: true,
+		},
+		{
+			name:         "node template",
+			template:     "node",
+			outputPath:   filepath.Join(tempDir, "tasks3.json"),
+			forceFlag:    false,
+			expectError:  false,
+			checkContent: true,
+		},
+		{
+			name:        "invalid template",
+			template:    "invalid",
+			outputPath:  filepath.Join(tempDir, "tasks4.json"),
+			forceFlag:   false,
+			expectError: true,
+		},
+		{
+			name:       "force overwrite existing file",
+			template:   "default",
+			outputPath: filepath.Join(tempDir, "tasks5.json"),
+			forceFlag:  true,
+			setupFunc: func() error {
+				return os.WriteFile(filepath.Join(tempDir, "tasks5.json"), []byte("existing content"), 0644)
+			},
+			expectError:  false,
+			checkContent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up test environment
+			verbose = false
+			quiet = true
+			templateName = tt.template
+			forceFlag = tt.forceFlag
+			outputPath = tt.outputPath
+
+			// Setup function if provided
+			if tt.setupFunc != nil {
+				if err := tt.setupFunc(); err != nil {
+					t.Fatalf("setup failed: %v", err)
+				}
+			}
+
+			// Run command
+			err := runInitCommand(nil, []string{})
+
+			// Check results
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+
+				// Check if file was created
+				if _, err := os.Stat(tt.outputPath); os.IsNotExist(err) {
+					t.Errorf("expected file to be created at %s", tt.outputPath)
+				}
+
+				// Check content if requested
+				if tt.checkContent {
+					content, err := os.ReadFile(tt.outputPath)
+					if err != nil {
+						t.Errorf("failed to read created file: %v", err)
+					} else {
+						contentStr := string(content)
+						if !strings.Contains(contentStr, `"version": "2.0.0"`) {
+							t.Errorf("expected tasks.json format, got: %s", contentStr)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidTemplate(t *testing.T) {
+	tests := []struct {
+		template string
+		expected bool
+	}{
+		{"default", true},
+		{"go", true},
+		{"node", true},
+		{"invalid", false},
+		{"", false},
+		{"Default", false}, // case sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.template, func(t *testing.T) {
+			result := isValidTemplate(tt.template)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestCreateDirectoryIfNeeded(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "jtask-dir-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name        string
+		filePath    string
+		expectError bool
+	}{
+		{
+			name:        "create nested directory",
+			filePath:    filepath.Join(tempDir, "nested", "dir", "file.json"),
+			expectError: false,
+		},
+		{
+			name:        "file in current directory",
+			filePath:    "file.json",
+			expectError: false,
+		},
+		{
+			name:        "existing directory",
+			filePath:    filepath.Join(tempDir, "file.json"),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := createDirectoryIfNeeded(tt.filePath)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+
+				// Check if directory was created (except for current directory case)
+				if tt.filePath != "file.json" {
+					dir := filepath.Dir(tt.filePath)
+					if _, err := os.Stat(dir); os.IsNotExist(err) {
+						t.Errorf("expected directory to be created: %s", dir)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetTemplateContent(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateName string
+		expectError  bool
+		expectEmpty  bool
+	}{
+		{
+			name:         "default template",
+			templateName: "default",
+			expectError:  false,
+			expectEmpty:  false,
+		},
+		{
+			name:         "go template",
+			templateName: "go",
+			expectError:  false,
+			expectEmpty:  false,
+		},
+		{
+			name:         "node template",
+			templateName: "node",
+			expectError:  false,
+			expectEmpty:  false,
+		},
+		{
+			name:         "non-existent template",
+			templateName: "nonexistent",
+			expectError:  true,
+			expectEmpty:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := GetTemplateContent(tt.templateName)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+
+			if tt.expectEmpty {
+				if content != "" {
+					t.Errorf("expected empty content, got: %s", content)
+				}
+			} else {
+				if content == "" {
+					t.Errorf("expected non-empty content")
+				}
+				// Verify it's valid JSON-like content
+				if !strings.Contains(content, `"version"`) || !strings.Contains(content, `"tasks"`) {
+					t.Errorf("expected tasks.json format, got: %s", content)
+				}
+			}
+		})
+	}
+}
+
+func TestGetAvailableTemplates(t *testing.T) {
+	templates := GetAvailableTemplates()
+	
+	expectedTemplates := []string{"default", "go", "node"}
+	
+	if len(templates) != len(expectedTemplates) {
+		t.Errorf("expected %d templates, got %d", len(expectedTemplates), len(templates))
+	}
+
+	for _, expected := range expectedTemplates {
+		found := false
+		for _, template := range templates {
+			if template == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected template '%s' not found in available templates", expected)
+		}
+	}
+}
+
+func TestWriteTemplateToFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "jtask-write-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	testContent := `{"test": "content"}`
+	testFile := filepath.Join(tempDir, "test.json")
+
+	err = writeTemplateToFile(testFile, testContent)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify file was written correctly
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Errorf("failed to read written file: %v", err)
+	}
+
+	if string(content) != testContent {
+		t.Errorf("expected content '%s', got '%s'", testContent, string(content))
+	}
+}

--- a/cmd/templates/default.json
+++ b/cmd/templates/default.json
@@ -1,0 +1,26 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "shell",
+      "command": "echo",
+      "args": ["Build task - replace with your build command"],
+      "group": "build"
+    },
+    {
+      "label": "test",
+      "type": "shell", 
+      "command": "echo",
+      "args": ["Test task - replace with your test command"],
+      "group": "test"
+    },
+    {
+      "label": "clean",
+      "type": "shell",
+      "command": "echo",
+      "args": ["Clean task - replace with your clean command"],
+      "group": "build"
+    }
+  ]
+}

--- a/cmd/templates/go.json
+++ b/cmd/templates/go.json
@@ -1,0 +1,81 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "shell",
+      "command": "go",
+      "args": ["build", "-o", "${workspaceFolderBasename}", "."],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    },
+    {
+      "label": "test",
+      "type": "shell",
+      "command": "go",
+      "args": ["test", "-v", "./..."],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    },
+    {
+      "label": "test-coverage",
+      "type": "shell",
+      "command": "go",
+      "args": ["test", "-v", "-coverprofile=coverage.out", "./..."],
+      "group": "test",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    },
+    {
+      "label": "run",
+      "type": "shell",
+      "command": "go",
+      "args": ["run", "."],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    },
+    {
+      "label": "clean",
+      "type": "shell",
+      "command": "go",
+      "args": ["clean"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    },
+    {
+      "label": "lint",
+      "type": "shell",
+      "command": "golangci-lint",
+      "args": ["run"],
+      "group": "test",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    },
+    {
+      "label": "mod-tidy",
+      "type": "shell",
+      "command": "go",
+      "args": ["mod", "tidy"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    }
+  ]
+}

--- a/cmd/templates/node.json
+++ b/cmd/templates/node.json
@@ -1,0 +1,108 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "install",
+      "type": "shell",
+      "command": "npm",
+      "args": ["install"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    },
+    {
+      "label": "build",
+      "type": "shell",
+      "command": "npm",
+      "args": ["run", "build"],
+      "group": {
+        "kind": "build", 
+        "isDefault": true
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "dependsOn": "install"
+    },
+    {
+      "label": "test",
+      "type": "shell",
+      "command": "npm",
+      "args": ["test"],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "dependsOn": "install"
+    },
+    {
+      "label": "test-watch",
+      "type": "shell",
+      "command": "npm",
+      "args": ["run", "test:watch"],
+      "group": "test",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "dependsOn": "install"
+    },
+    {
+      "label": "start",
+      "type": "shell",
+      "command": "npm",
+      "args": ["start"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "dependsOn": "install"
+    },
+    {
+      "label": "dev",
+      "type": "shell",
+      "command": "npm",
+      "args": ["run", "dev"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "dependsOn": "install"
+    },
+    {
+      "label": "lint",
+      "type": "shell",
+      "command": "npm",
+      "args": ["run", "lint"],
+      "group": "test",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "dependsOn": "install"
+    },
+    {
+      "label": "lint-fix",
+      "type": "shell",
+      "command": "npm",
+      "args": ["run", "lint:fix"],
+      "group": "test",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "dependsOn": "install"
+    },
+    {
+      "label": "clean",
+      "type": "shell",
+      "command": "rm",
+      "args": ["-rf", "node_modules", "dist", "build"],
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Implement `jtask init` command with template-based tasks.json creation
- Add default, go, and node templates with embedded file system
- Support interactive confirmation and command-line flags
- Comprehensive unit test coverage with edge cases

## Features
- Template support: `--template default|go|node`
- Force overwrite: `--force` flag
- Custom output path: `--output` flag
- Interactive confirmation for existing files
- Embedded template files for easy distribution

## Test plan
- [x] Unit tests for all functionality
- [x] Manual testing of all templates (default, go, node)
- [x] Error handling for invalid templates
- [x] File overwrite confirmation
- [x] Linter compliance

🤖 Generated with [Claude Code](https://claude.ai/code)