### PR TITLE
Implement npm and typescript task type support

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -164,17 +164,8 @@ func validateTasks(tasks []config.Task, result *ValidationResult) {
 			})
 		}
 		
-		if task.Command == "" {
-			result.Valid = false
-			result.Errors = append(result.Errors, ValidationError{
-				Type:      "missing_command",
-				Message:   "task is missing required 'command' field",
-				TaskLabel: task.Label,
-			})
-		}
-		
 		// Validate task type
-		validTypes := []string{"shell", "process"}
+		validTypes := []string{"shell", "process", "npm", "typescript"}
 		isValidType := false
 		for _, validType := range validTypes {
 			if task.Type == validType {
@@ -186,6 +177,26 @@ func validateTasks(tasks []config.Task, result *ValidationResult) {
 			result.Warnings = append(result.Warnings, ValidationError{
 				Type:      "unknown_type",
 				Message:   fmt.Sprintf("unknown task type '%s', supported types: %v", task.Type, validTypes),
+				TaskLabel: task.Label,
+			})
+		}
+		
+		// Validate type-specific required fields
+		if task.Type == "npm" && task.Script == "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, ValidationError{
+				Type:      "missing_script",
+				Message:   "npm task requires 'script' field",
+				TaskLabel: task.Label,
+			})
+		}
+		
+		// Validate command field requirements based on task type
+		if (task.Type == "shell" || task.Type == "process") && task.Command == "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, ValidationError{
+				Type:      "missing_command",
+				Message:   "shell and process tasks require 'command' field",
 				TaskLabel: task.Label,
 			})
 		}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -47,6 +47,53 @@ func TestValidateTasksFile(t *testing.T) {
 			expectWarnings: 0,
 		},
 		{
+			name: "npm task valid",
+			content: `{
+				"version": "2.0.0",
+				"tasks": [
+					{
+						"label": "start",
+						"type": "npm",
+						"script": "start"
+					}
+				]
+			}`,
+			expectValid: true,
+			expectErrors: 0,
+			expectWarnings: 0,
+		},
+		{
+			name: "typescript task valid",
+			content: `{
+				"version": "2.0.0",
+				"tasks": [
+					{
+						"label": "build",
+						"type": "typescript",
+						"tsconfig": "tsconfig.json"
+					}
+				]
+			}`,
+			expectValid: true,
+			expectErrors: 0,
+			expectWarnings: 0,
+		},
+		{
+			name: "npm task missing script",
+			content: `{
+				"version": "2.0.0",
+				"tasks": [
+					{
+						"label": "start",
+						"type": "npm"
+					}
+				]
+			}`,
+			expectValid: false,
+			expectErrors: 1,
+			expectWarnings: 0,
+		},
+		{
 			name: "missing required fields",
 			content: `{
 				"version": "2.0.0",
@@ -57,7 +104,7 @@ func TestValidateTasksFile(t *testing.T) {
 				]
 			}`,
 			expectValid: false,
-			expectErrors: 2,
+			expectErrors: 1,
 			expectWarnings: 1,
 		},
 		{
@@ -145,13 +192,13 @@ func TestValidateTasksFile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.Remove(tmpFile.Name())
+			defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 			// Write test content
 			if _, err := tmpFile.WriteString(tt.content); err != nil {
 				t.Fatal(err)
 			}
-			tmpFile.Close()
+			_ = tmpFile.Close()
 
 			// Validate the file
 			result := validateTasksFile(tmpFile.Name())
@@ -198,7 +245,7 @@ func TestValidateWorkingDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create tasks.json with valid working directory
 	validContent := `{
@@ -219,12 +266,12 @@ func TestValidateWorkingDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	if _, err := tmpFile.WriteString(validContent); err != nil {
 		t.Fatal(err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	result := validateTasksFile(tmpFile.Name())
 	if !result.Valid {
@@ -254,12 +301,12 @@ func TestValidateWorkingDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpFile2.Name())
+	defer func() { _ = os.Remove(tmpFile2.Name()) }()
 
 	if _, err := tmpFile2.WriteString(invalidContent); err != nil {
 		t.Fatal(err)
 	}
-	tmpFile2.Close()
+	_ = tmpFile2.Close()
 
 	result2 := validateTasksFile(tmpFile2.Name())
 	if !result2.Valid {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -86,7 +86,7 @@ func executeWatchCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create file watcher: %w", err)
 	}
-	defer watcher.Close()
+	defer func() { _ = watcher.Close() }()
 
 	// Set default watch paths if none specified
 	if len(watchPaths) == 0 {

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -113,7 +113,7 @@ func TestAddWatchPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer watcher.Close()
+	defer func() { _ = watcher.Close() }()
 
 	// Save original exclude list
 	origExcludes := watchExclude
@@ -135,7 +135,7 @@ func TestAddWatchPath_NonExistentPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer watcher.Close()
+	defer func() { _ = watcher.Close() }()
 
 	err = addWatchPath(watcher, "/nonexistent/path")
 	if err == nil {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -17,6 +17,14 @@ type Task struct {
 	DependsOrder    string            `json:"dependsOrder,omitempty"`
 	Presentation    *TaskPresentation `json:"presentation,omitempty"`
 	RunOptions      *TaskRunOptions   `json:"runOptions,omitempty"`
+	
+	// TypeScript task specific fields
+	TSConfig        string            `json:"tsconfig,omitempty"`
+	Option          string            `json:"option,omitempty"`
+	
+	// NPM task specific fields
+	Script          string            `json:"script,omitempty"`
+	Path            string            `json:"path,omitempty"`
 }
 
 type TaskOptions struct {

--- a/internal/executor/runner_npm_test.go
+++ b/internal/executor/runner_npm_test.go
@@ -1,0 +1,102 @@
+package executor
+
+import (
+	"testing"
+	"path/filepath"
+	"strings"
+
+	"github.com/garaemon/tasks-json-cli/internal/config"
+)
+
+func TestBuildNpmCommand(t *testing.T) {
+	workspaceDir := "/workspace"
+	
+	tests := []struct {
+		name         string
+		task         *config.Task
+		expectedCmd  string
+		expectedArgs []string
+		expectedDir  string
+		expectError  bool
+	}{
+		{
+			name: "simple npm task",
+			task: &config.Task{
+				Type:   "npm",
+				Script: "start",
+			},
+			expectedCmd:  "npm",
+			expectedArgs: []string{"run", "start"},
+			expectedDir:  workspaceDir,
+			expectError:  false,
+		},
+		{
+			name: "npm task with path",
+			task: &config.Task{
+				Type:   "npm",
+				Script: "build",
+				Path:   "frontend",
+			},
+			expectedCmd:  "npm",
+			expectedArgs: []string{"run", "build"},
+			expectedDir:  filepath.Join(workspaceDir, "frontend"),
+			expectError:  false,
+		},
+		{
+			name: "npm task with absolute path",
+			task: &config.Task{
+				Type:   "npm",
+				Script: "test",
+				Path:   "/absolute/path",
+			},
+			expectedCmd:  "npm",
+			expectedArgs: []string{"run", "test"},
+			expectedDir:  "/absolute/path",
+			expectError:  false,
+		},
+		{
+			name: "npm task without script",
+			task: &config.Task{
+				Type: "npm",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := buildNpmCommand(tt.task, workspaceDir)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			
+			// Check that the command ends with npm (path may vary)
+			if !strings.HasSuffix(cmd.Path, "npm") && cmd.Path != tt.expectedCmd {
+				t.Errorf("expected command to end with %q, got %q", tt.expectedCmd, cmd.Path)
+			}
+			
+			if len(cmd.Args) != len(tt.expectedArgs)+1 { // +1 for command name
+				t.Errorf("expected %d args, got %d", len(tt.expectedArgs), len(cmd.Args)-1)
+			} else {
+				for i, expectedArg := range tt.expectedArgs {
+					if cmd.Args[i+1] != expectedArg { // +1 to skip command name
+						t.Errorf("expected arg[%d] %q, got %q", i, expectedArg, cmd.Args[i+1])
+					}
+				}
+			}
+			
+			if cmd.Dir != tt.expectedDir {
+				t.Errorf("expected dir %q, got %q", tt.expectedDir, cmd.Dir)
+			}
+		})
+	}
+}

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -158,19 +158,37 @@ func TestRunTask_UnsupportedType(t *testing.T) {
 }
 
 func TestRunTask_EmptyCommand(t *testing.T) {
-	task := &config.Task{
+	// Test shell task with empty command (should fail)
+	shellTask := &config.Task{
 		Type:    "shell",
 		Command: "",
 	}
 
-	err := RunTask(task, "/tmp", "")
-	
+	err := RunTask(shellTask, "/tmp", "")
 	if err == nil {
-		t.Error("expected error for empty command")
+		t.Error("expected error for empty command in shell task")
 	}
 	
-	if err.Error() != "task command is empty" {
-		t.Errorf("expected error message about empty command, got %s", err.Error())
+	// Test npm task without script (should fail)
+	npmTask := &config.Task{
+		Type: "npm",
+	}
+
+	err = RunTask(npmTask, "/tmp", "")
+	if err == nil {
+		t.Error("expected error for npm task without script")
+	}
+	
+	// Test typescript task (should succeed)
+	tsTask := &config.Task{
+		Type: "typescript",
+	}
+
+	// This should not fail due to empty command since typescript tasks don't require command
+	err = RunTask(tsTask, "/tmp", "")
+	// We expect this to fail for other reasons (tsc not found), but not due to empty command
+	if err != nil && strings.Contains(err.Error(), "task command is empty") {
+		t.Error("typescript task should not fail due to empty command")
 	}
 }
 

--- a/internal/executor/runner_typescript_test.go
+++ b/internal/executor/runner_typescript_test.go
@@ -1,0 +1,101 @@
+package executor
+
+import (
+	"testing"
+	"strings"
+
+	"github.com/garaemon/tasks-json-cli/internal/config"
+)
+
+func TestBuildTypescriptCommand(t *testing.T) {
+	workspaceDir := "/workspace"
+	
+	tests := []struct {
+		name         string
+		task         *config.Task
+		expectedCmd  string
+		expectedArgs []string
+		expectedDir  string
+	}{
+		{
+			name: "simple typescript task",
+			task: &config.Task{
+				Type: "typescript",
+			},
+			expectedCmd:  "tsc",
+			expectedArgs: []string{},
+			expectedDir:  workspaceDir,
+		},
+		{
+			name: "typescript task with tsconfig",
+			task: &config.Task{
+				Type:     "typescript",
+				TSConfig: "tsconfig.json",
+			},
+			expectedCmd:  "tsc",
+			expectedArgs: []string{"-p", "tsconfig.json"},
+			expectedDir:  workspaceDir,
+		},
+		{
+			name: "typescript task with watch option",
+			task: &config.Task{
+				Type:   "typescript",
+				Option: "watch",
+			},
+			expectedCmd:  "tsc",
+			expectedArgs: []string{"--watch"},
+			expectedDir:  workspaceDir,
+		},
+		{
+			name: "typescript task with tsconfig and watch",
+			task: &config.Task{
+				Type:     "typescript",
+				TSConfig: "tsconfig.build.json",
+				Option:   "watch",
+			},
+			expectedCmd:  "tsc",
+			expectedArgs: []string{"-p", "tsconfig.build.json", "--watch"},
+			expectedDir:  workspaceDir,
+		},
+		{
+			name: "typescript task with custom option",
+			task: &config.Task{
+				Type:   "typescript",
+				Option: "--noEmit",
+			},
+			expectedCmd:  "tsc",
+			expectedArgs: []string{"--noEmit"},
+			expectedDir:  workspaceDir,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := buildTypescriptCommand(tt.task, workspaceDir)
+			
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			
+			// Check that the command ends with tsc (path may vary)
+			if !strings.HasSuffix(cmd.Path, "tsc") && cmd.Path != tt.expectedCmd {
+				t.Errorf("expected command to end with %q, got %q", tt.expectedCmd, cmd.Path)
+			}
+			
+			if len(cmd.Args) != len(tt.expectedArgs)+1 { // +1 for command name
+				t.Errorf("expected %d args, got %d", len(tt.expectedArgs), len(cmd.Args)-1)
+			} else {
+				for i, expectedArg := range tt.expectedArgs {
+					if cmd.Args[i+1] != expectedArg { // +1 to skip command name
+						t.Errorf("expected arg[%d] %q, got %q", i, expectedArg, cmd.Args[i+1])
+					}
+				}
+			}
+			
+			if cmd.Dir != tt.expectedDir {
+				t.Errorf("expected dir %q, got %q", tt.expectedDir, cmd.Dir)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR implements support for npm and typescript task types in tasks-json-cli, matching VS Code's task functionality.

### Changes
- ✅ **npm task type**: Execute npm scripts with `script` and optional `path` fields
- ✅ **typescript task type**: Run TypeScript compiler with `tsconfig` and `option` fields
- ✅ **Enhanced validation**: Support new task types with proper field requirements
- ✅ **Variable substitution**: Full VS Code variable support in new task-specific fields
- ✅ **Comprehensive tests**: Test coverage for both task types and validation
- ✅ **Linter fixes**: Resolved all errcheck issues in test files

### Task Type Examples

**NPM Task:**
```json
{
  "label": "npm-build",
  "type": "npm",
  "script": "build",
  "path": "frontend"
}
```

**TypeScript Task:**
```json
{
  "label": "typescript-watch", 
  "type": "typescript",
  "tsconfig": "tsconfig.json",
  "option": "watch"
}
```

## Test plan
- [x] All existing tests pass
- [x] New npm task type tests pass
- [x] New typescript task type tests pass
- [x] Validation tests for new task types pass
- [x] Linter passes with 0 issues
- [x] Manual testing with example package.json and tasks.json

🤖 Generated with [Claude Code](https://claude.ai/code)